### PR TITLE
Removed launch type parameter

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -8,7 +8,6 @@ containerPort: 8080
 healthCheck: /geoserver/web/
 gitRepoUrl: https://github.com/usgs/iow-geoserver.git
 gitRepoCredentialsId: GITHUB_ACCESS_TOKEN
-launchType: FARGATE
 listenerPort: 443
 envVars:
   - name: GEOSERVER_DATA_DIR


### PR DESCRIPTION
Launch type parameter was being handled incorrectly. Removing for now so that it defaults to Fargate.